### PR TITLE
Issue #2971749 by jjchinquist: Permission for the admin settings form should be "administer ivw integration configuration"

### DIFF
--- a/ivw_integration.install
+++ b/ivw_integration.install
@@ -5,6 +5,8 @@
  * Contains installation hooks for module.
  */
 
+use Drupal\user\Entity\Role;
+
 /**
  * Implements hook_requirements().
  */
@@ -113,4 +115,16 @@ function ivw_integration_add_missing_field_columns($field_type) {
 function ivw_integration_update_8101() {
   $messages = ivw_integration_add_missing_field_columns('ivw_integration_settings');
   return implode('<br /><br />', $messages);
+}
+
+/**
+ * Update all current users for the new permission.
+ */
+function ivw_integration_update_8102() {
+  $roles = Role::loadMultiple();
+  foreach ($roles as $role) {
+    if ($role->hasPermission("administer site configuration")) {
+      $role->grantPermission("administer ivw integration configuration");
+    }
+  }
 }

--- a/ivw_integration.permissions.yml
+++ b/ivw_integration.permissions.yml
@@ -1,0 +1,3 @@
+administer ivw integration configuration:
+  title: 'Administer IVW integration configuration'
+  description: 'Allows the administrator to access the IVW integration page and update settings.'

--- a/ivw_integration.routing.yml
+++ b/ivw_integration.routing.yml
@@ -4,4 +4,4 @@ ivw_integration.admin_settings:
     _form: '\Drupal\ivw_integration\Form\SettingsForm'
     _title: 'IVW settings'
   requirements:
-    _permission: 'administer site configuration'
+    _permission: 'administer ivw integration configuration'


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/8.x-1.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
