### PR TITLE
Issue #2881194 by mbm80: Arrays are not allowed in class constants in php version 5.6+

### DIFF
--- a/src/IvwLookupService.php
+++ b/src/IvwLookupService.php
@@ -19,7 +19,6 @@ use Drupal\taxonomy\TermInterface;
  */
 class IvwLookupService implements IvwLookupServiceInterface {
 
-  const SUPPORTED_ENTITY_PARAMETERS = ['node', 'media', 'taxonomy_term'];
   /**
    * The route match.
    *
@@ -56,6 +55,15 @@ class IvwLookupService implements IvwLookupServiceInterface {
   }
 
   /**
+   * Gets the supported entity parameters.
+   *
+   * @return array
+   */
+  public static function getSupportedEntityParameters() {
+    return ['node', 'media', 'taxonomy_term'];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function byCurrentRoute($name, $parentOnly = FALSE) {
@@ -69,7 +77,7 @@ class IvwLookupService implements IvwLookupServiceInterface {
 
     $entity = NULL;
 
-    foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
+    foreach (self::getSupportedEntityParameters() as $parameter) {
       /* @var ContentEntityInterface $entity */
       if ($entity = $route->getParameter($parameter)) {
 
@@ -111,7 +119,7 @@ class IvwLookupService implements IvwLookupServiceInterface {
     $entity = NULL;
     $cache_tags = [];
 
-    foreach (static::SUPPORTED_ENTITY_PARAMETERS as $parameter) {
+    foreach (self::getSupportedEntityParameters() as $parameter) {
       /* @var ContentEntityInterface $entity */
       if ($entity = $route->getParameter($parameter)) {
 


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/8.x-1.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
