### PR TITLE
Remove dependency on breakpoints_js_settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
   "license": "GPL-2.0-or-later",
   "minimum-stability": "dev",
   "require": {
-    "drupal/breakpoint_js_settings": "~1.0",
     "drupal/core": "^8.8|^9.0"
   },
   "require-dev": {


### PR DESCRIPTION
I can't find any place where this module is dependend on breakpoints_js_settings. So lets remove it.

Make sure these boxes are checked before submitting your pull request - thank you!

- [ ] All coding styles are fulfilled. ([How to check for cs issues?](https://github.com/BurdaMagazinOrg/thunder-dev-tools/blob/master/README.md#code-style-guidelines))
- [ ] All tests are running locally. ([How to run the test?](https://github.com/BurdaMagazinOrg/thunder-distribution/blob/8.x-1.x/docs/development.md#how-to-run-the-tests))
- [ ] Necessary update hooks are provided.
- [ ] User roles have correct access for new introduced permission.
- [ ] Every thunder module has a README.md in its root. Follow [this guidelines](https://www.drupal.org/node/2181737), but we don't need every topic.
- [ ] Code is covered with well-balanced amount of inline comments.

If you are really awesome, then your feature is covered by additional tests. Well done!
